### PR TITLE
Only install if required

### DIFF
--- a/manifests/settings.pp
+++ b/manifests/settings.pp
@@ -1,35 +1,42 @@
 # Create a maven settings file
-class maven::settings ( $password_file = undef ) {
+class maven::settings ( $home = undef,
+  $local_repository = undef,
+  $password_file = undef,
+  $local_profile_name = 'default',
+  $mirrors  = [],
+  $repos    = [],
+  $properties = [],
+  $servers  = [],
+  $proxies  = [],) {
 
+  $m2 = "$home/.m2"
   $created_file = "/var/db/.puppet_exec_installed_maven_settings"
 
-  file { "${homedir}/.m2":
+  if $local_repository == undef {
+    $local_repo = "$m2/repository"
+  }
+  else
+  {
+    $local_repo = $local_repository
+  }
+
+  file { "$m2":
     ensure => "directory",
     owner  => "${::luser}",
-    mode  => "700",
-    cwd   => "${homedir}",
-    refreshonly => true
+    mode  => "700"
   }
 
   file { "/tmp/create_mvn_security":
     ensure => "present",
     source => "puppet:///modules/maven/create_settings_security.sh",
     mode   => "0755",
-    backup => "false",
-    refreshonly => true 
+    backup => "false"
   }
 
-  exec { "settings-security":
-    command =>  "/tmp/create_mvn_security",
-    require => [File["${homedir}/.m2"], File["/tmp/create_mvn_security"]]
-    refreshonly => true
-  }
-
-  file { "${homedir}/.m2/settings.xml":
+  file { "$m2/settings.xml":
     ensure    => "present",
     content   => template("maven/settings.xml.erb"),
     replace   => "no",
-    refreshonly => true
   }
 
   file { "/tmp/mvn_passwd":
@@ -37,26 +44,18 @@ class maven::settings ( $password_file = undef ) {
     source => "puppet:///modules/maven/append_mvn_encryptedpass.sh",
     mode => "0755",
     backup => "false",
-    refreshonly => true
   }
 
-  exec { "passfile_exists":
-    command => "test -e ${password_file}",
-    refreshonly => true
-  }
-
-  # clean up empty passwords
-  exec { "add_passwords":
-    command => "/tmp/mvn_passwd ${password_file}",
-    require => [Exec["settings-security"], File["${homedir}/.m2/settings.xml"], File["/tmp/mvn_passwd"], Exec["passfile_exists"]]
-    refreshonly => true
-  }
-
-  # only execute the chain if the created file is absent
-  exec { "maven_settings":
-    command => "touch $created_file",
+  # only execute the command if the created file is absent
+  exec { "create_maven_settings":
+    command => "/tmp/create_mvn_security \
+                && test -e $password_file \
+                && /tmp/mvn_passwd $password_file \
+                && touch $created_file",
+    user    => root,
+    cwd     => "/tmp",
     creates => $created_file,
-    require => Exec["add_passwords"]
+    require => [File["$m2"], File["/tmp/create_mvn_security"], File["$m2/settings.xml"], File["/tmp/mvn_passwd"]],
   }
 
 }


### PR DESCRIPTION
This implementation ensures that maven settings are not created if they have been noted as already existing through use of a .puppet... file (same mechanism used by puppet for other modules).  This removes the need for the passfile to exists if there is nothing to do.

I have tested it and it works great.
